### PR TITLE
add translation

### DIFF
--- a/AP_manual_align_histology_ccf.m
+++ b/AP_manual_align_histology_ccf.m
@@ -1,300 +1,333 @@
 function AP_manual_align_histology_ccf(tv,av,st,slice_im_path)
-% AP_manual_align_histology_ccf(tv,av,st,slice_im_path)
-%
-% Align histology slices and matched CCF slices
-% Andy Peters (peters.andrew.j@gmail.com)
-
-% Initialize guidata
-gui_data = struct;
-gui_data.tv = tv;
-gui_data.av = av;
-gui_data.st = st;
-
-% Load in slice images
-gui_data.slice_im_path = slice_im_path;
-slice_im_dir = dir([slice_im_path filesep '*.tif']);
-slice_im_fn = natsortfiles(cellfun(@(path,fn) [path filesep fn], ...
-    {slice_im_dir.folder},{slice_im_dir.name},'uni',false));
-gui_data.slice_im = cell(length(slice_im_fn),1);
-for curr_slice = 1:length(slice_im_fn)
-    gui_data.slice_im{curr_slice} = imread(slice_im_fn{curr_slice});
-end
-
-% Load corresponding CCF slices
-ccf_slice_fn = [slice_im_path filesep 'histology_ccf.mat'];
-load(ccf_slice_fn);
-gui_data.histology_ccf = histology_ccf;
-
-% Load automated alignment
-auto_ccf_alignment_fn = [slice_im_path filesep 'atlas2histology_tform.mat'];
-if exist(auto_ccf_alignment_fn,'file')
-    load(auto_ccf_alignment_fn);
-    gui_data.histology_ccf_auto_alignment = atlas2histology_tform;
-end
-
-% Create figure, set button functions
-gui_fig = figure('KeyPressFcn',@keypress);
-gui_data.curr_slice = 1;
-
-% Set up axis for histology image
-gui_data.histology_ax = subplot(1,2,1,'YDir','reverse'); 
-set(gui_data.histology_ax,'Position',[0,0,0.5,0.9]);
-hold on; colormap(gray); axis image off;
-gui_data.histology_im_h = image(gui_data.slice_im{1}, ...
-    'Parent',gui_data.histology_ax,'ButtonDownFcn',@mouseclick_histology);
-
-% Set up histology-aligned atlas overlay
-% (and make it invisible to mouse clicks)
-histology_aligned_atlas_boundaries_init = ...
-    zeros(size(gui_data.slice_im{1},1),size(gui_data.slice_im{1},2));
-gui_data.histology_aligned_atlas_boundaries = ...
-    imagesc(histology_aligned_atlas_boundaries_init,'Parent',gui_data.histology_ax, ...
-    'AlphaData',histology_aligned_atlas_boundaries_init,'PickableParts','none');
-
-% Set up axis for atlas slice
-gui_data.atlas_ax = subplot(1,2,2,'YDir','reverse'); 
-set(gui_data.atlas_ax,'Position',[0.5,0,0.5,0.9]);
-hold on; axis image off; colormap(gray); caxis([0,400]);
-gui_data.atlas_im_h = imagesc(gui_data.histology_ccf(1).tv_slices, ...
-    'Parent',gui_data.atlas_ax,'ButtonDownFcn',@mouseclick_atlas);
-
-% Initialize alignment control points and tform matricies
-gui_data.histology_control_points = repmat({zeros(0,2)},length(gui_data.slice_im),1);
-gui_data.atlas_control_points = repmat({zeros(0,2)},length(gui_data.slice_im),1);
-
-gui_data.histology_control_points_plot = plot(gui_data.histology_ax,nan,nan,'.w','MarkerSize',20);
-gui_data.atlas_control_points_plot = plot(gui_data.atlas_ax,nan,nan,'.r','MarkerSize',20);
-
-gui_data.histology_ccf_manual_alignment = gui_data.histology_ccf_auto_alignment;
-
-% Upload gui data
-guidata(gui_fig,gui_data);
-
-% Initialize alignment
-align_ccf_to_histology(gui_fig);
-
-% Print controls
-CreateStruct.Interpreter = 'tex';
-CreateStruct.WindowStyle = 'non-modal';
-msgbox( ...
-    {'\fontsize{12}' ...
-    '\bf Controls: \rm' ...
-    '1,2 : switch slice' ...
-    'click : set reference points for manual alignment (3 minimum)', ...
-    'space : toggle alignment overlay visibility', ...
-    'c : clear manually placed points', ...
-    's : save', ...
-    'Escape: save and close'}, ...
-    'Controls',CreateStruct);
-
+	% AP_manual_align_histology_ccf(tv,av,st,slice_im_path)
+	%
+	% Align histology slices and matched CCF slices
+	% Andy Peters (peters.andrew.j@gmail.com)
+	
+	% Initialize guidata
+	gui_data = struct;
+	gui_data.tv = tv;
+	gui_data.av = av;
+	gui_data.st = st;
+	
+	% Load in slice images
+	gui_data.slice_im_path = slice_im_path;
+	slice_im_dir = dir([slice_im_path filesep '*.tif']);
+	slice_im_fn = natsortfiles(cellfun(@(path,fn) [path filesep fn], ...
+		{slice_im_dir.folder},{slice_im_dir.name},'uni',false));
+	gui_data.slice_im = cell(length(slice_im_fn),1);
+	for curr_slice = 1:length(slice_im_fn)
+		gui_data.slice_im{curr_slice} = imread(slice_im_fn{curr_slice});
+	end
+	
+	% Load corresponding CCF slices
+	ccf_slice_fn = [slice_im_path filesep 'histology_ccf.mat'];
+	load(ccf_slice_fn);
+	gui_data.histology_ccf = histology_ccf;
+	
+	% Load automated alignment
+	auto_ccf_alignment_fn = [slice_im_path filesep 'atlas2histology_tform.mat'];
+	if exist(auto_ccf_alignment_fn,'file')
+		load(auto_ccf_alignment_fn);
+		gui_data.histology_ccf_auto_alignment = atlas2histology_tform;
+	end
+	
+	%set initial translation offsets
+	gui_data.translateX = 0;
+	gui_data.translateY = 0;
+	
+	% Create figure, set button functions
+	gui_fig = figure('KeyPressFcn',@keypress);
+	gui_data.curr_slice = 1;
+	
+	% Set up axis for histology image
+	gui_data.histology_ax = subplot(1,2,1,'YDir','reverse');
+	set(gui_data.histology_ax,'Position',[0,0,0.5,0.9]);
+	hold on; colormap(gray); axis image off;
+	gui_data.histology_im_h = image(gui_data.slice_im{1}, ...
+		'Parent',gui_data.histology_ax,'ButtonDownFcn',@mouseclick_histology);
+	
+	% Set up histology-aligned atlas overlay
+	% (and make it invisible to mouse clicks)
+	histology_aligned_atlas_boundaries_init = ...
+		zeros(size(gui_data.slice_im{1},1),size(gui_data.slice_im{1},2));
+	gui_data.histology_aligned_atlas_boundaries = ...
+		imagesc(histology_aligned_atlas_boundaries_init,'Parent',gui_data.histology_ax, ...
+		'AlphaData',histology_aligned_atlas_boundaries_init,'PickableParts','none');
+	
+	% Set up axis for atlas slice
+	gui_data.atlas_ax = subplot(1,2,2,'YDir','reverse');
+	set(gui_data.atlas_ax,'Position',[0.5,0,0.5,0.9]);
+	hold on; axis image off; colormap(gray); caxis([0,400]);
+	gui_data.atlas_im_h = imagesc(gui_data.histology_ccf(1).tv_slices, ...
+		'Parent',gui_data.atlas_ax,'ButtonDownFcn',@mouseclick_atlas);
+	
+	% Initialize alignment control points and tform matricies
+	gui_data.histology_control_points = repmat({zeros(0,2)},length(gui_data.slice_im),1);
+	gui_data.atlas_control_points = repmat({zeros(0,2)},length(gui_data.slice_im),1);
+	
+	gui_data.histology_control_points_plot = plot(gui_data.histology_ax,nan,nan,'.w','MarkerSize',20);
+	gui_data.atlas_control_points_plot = plot(gui_data.atlas_ax,nan,nan,'.r','MarkerSize',20);
+	
+	gui_data.histology_ccf_manual_alignment = gui_data.histology_ccf_auto_alignment;
+	
+	% Upload gui data
+	guidata(gui_fig,gui_data);
+	
+	% Initialize alignment
+	align_ccf_to_histology(gui_fig);
+	
+	% Print controls
+	CreateStruct.Interpreter = 'tex';
+	CreateStruct.WindowStyle = 'non-modal';
+	msgbox( ...
+		{'\fontsize{12}' ...
+		'\bf Controls: \rm' ...
+		'1,2 : switch slice' ...
+		'click : set reference points for manual alignment (3 minimum)', ...
+		'arrow keys : translate atlas grid',...
+		'space : toggle alignment overlay visibility', ...
+		'c : clear manually placed points', ...
+		's : save', ...
+		'Escape: save and close'}, ...
+		'Controls',CreateStruct);
+	
 end
 
 
 function keypress(gui_fig,eventdata)
-
-% Get guidata
-gui_data = guidata(gui_fig);
-
-switch eventdata.Key
-    
-    % 1/2: move slice
-    case '1'
-        gui_data.curr_slice = max(gui_data.curr_slice - 1,1);
-        guidata(gui_fig,gui_data);
-        update_slice(gui_fig);
-        
-    case '2'
-        gui_data.curr_slice = ...
-            min(gui_data.curr_slice + 1,length(gui_data.slice_im));
-        guidata(gui_fig,gui_data);
-        update_slice(gui_fig);
-        
-    % O: toggle overlay visibility
-    case 'space'
-        curr_visibility = ...
-            get(gui_data.histology_aligned_atlas_boundaries,'Visible');
-        set(gui_data.histology_aligned_atlas_boundaries,'Visible', ...
-            cell2mat(setdiff({'on','off'},curr_visibility)))
-        
-    % C: clear current points
-    case 'c'
-        gui_data.histology_control_points{gui_data.curr_slice} = zeros(0,2);
-        gui_data.atlas_control_points{gui_data.curr_slice} = zeros(0,2);
-        
-        guidata(gui_fig,gui_data);
-        update_slice(gui_fig);
-        
-    % S: save
-    case 's'
-        atlas2histology_tform = ...
-            gui_data.histology_ccf_manual_alignment;
-        save_fn = [gui_data.slice_im_path filesep 'atlas2histology_tform.mat'];
-        save(save_fn,'atlas2histology_tform');
-        disp(['Saved ' save_fn]);
-        
-    % Escape: save and exit
-    case 'escape'
-        opts.Default = 'Yes';
-        opts.Interpreter = 'tex';
-        user_confirm = questdlg('\fontsize{15} Save and quit?','Confirm exit',opts);
-        if strcmp(user_confirm,'Yes')            
-            atlas2histology_tform = ...
-                gui_data.histology_ccf_manual_alignment;
-            save_fn = [gui_data.slice_im_path filesep 'atlas2histology_tform.mat'];
-            save(save_fn,'atlas2histology_tform');
-            disp(['Saved ' save_fn]);
-            close(gui_fig);            
-        end
-        
-end
-
+	
+	% Get guidata
+	gui_data = guidata(gui_fig);
+	
+	switch eventdata.Key
+		case 'leftarrow'
+			gui_data.translateX = gui_data.translateX - 1;
+			guidata(gui_fig,gui_data);
+			align_ccf_to_histology(gui_fig);
+		case 'rightarrow'
+			gui_data.translateX = gui_data.translateX + 1;
+			guidata(gui_fig,gui_data);
+			align_ccf_to_histology(gui_fig);
+		case 'uparrow'
+			gui_data.translateY = gui_data.translateY - 1;
+			guidata(gui_fig,gui_data);
+			align_ccf_to_histology(gui_fig);
+		case 'downarrow'
+			gui_data.translateY = gui_data.translateY + 1;
+			guidata(gui_fig,gui_data);
+			align_ccf_to_histology(gui_fig);
+			
+		% 1/2: move slice
+		case '1'
+			gui_data.curr_slice = max(gui_data.curr_slice - 1,1);
+			guidata(gui_fig,gui_data);
+			update_slice(gui_fig);
+			
+		case '2'
+			gui_data.curr_slice = ...
+				min(gui_data.curr_slice + 1,length(gui_data.slice_im));
+			guidata(gui_fig,gui_data);
+			update_slice(gui_fig);
+			
+			% O: toggle overlay visibility
+		case 'space'
+			curr_visibility = ...
+				get(gui_data.histology_aligned_atlas_boundaries,'Visible');
+			set(gui_data.histology_aligned_atlas_boundaries,'Visible', ...
+				cell2mat(setdiff({'on','off'},curr_visibility)))
+			
+			% C: clear current points
+		case 'c'
+			gui_data.histology_control_points{gui_data.curr_slice} = zeros(0,2);
+			gui_data.atlas_control_points{gui_data.curr_slice} = zeros(0,2);
+			
+			guidata(gui_fig,gui_data);
+			update_slice(gui_fig);
+			
+			% S: save
+		case 's'
+			atlas2histology_tform = ...
+				gui_data.histology_ccf_manual_alignment;
+			save_fn = [gui_data.slice_im_path filesep 'atlas2histology_tform.mat'];
+			save(save_fn,'atlas2histology_tform');
+			disp(['Saved ' save_fn]);
+			
+			% Escape: save and exit
+		case 'escape'
+			opts.Default = 'Yes';
+			opts.Interpreter = 'tex';
+			user_confirm = questdlg('\fontsize{15} Save and quit?','Confirm exit',opts);
+			if strcmp(user_confirm,'Yes')
+				atlas2histology_tform = ...
+					gui_data.histology_ccf_manual_alignment;
+				save_fn = [gui_data.slice_im_path filesep 'atlas2histology_tform.mat'];
+				save(save_fn,'atlas2histology_tform');
+				disp(['Saved ' save_fn]);
+				close(gui_fig);
+			end
+			
+	end
+	
 end
 
 
 function mouseclick_histology(gui_fig,eventdata)
-% Draw new point for alignment
-
-% Get guidata
-gui_data = guidata(gui_fig);
-
-% Add clicked location to control points
-gui_data.histology_control_points{gui_data.curr_slice} = ...
-    vertcat(gui_data.histology_control_points{gui_data.curr_slice}, ...
-    eventdata.IntersectionPoint(1:2));
-
-set(gui_data.histology_control_points_plot, ...
-    'XData',gui_data.histology_control_points{gui_data.curr_slice}(:,1), ...
-    'YData',gui_data.histology_control_points{gui_data.curr_slice}(:,2));
-
-% Upload gui data
-guidata(gui_fig, gui_data);
-
-% If equal number of histology/atlas control points > 3, draw boundaries
-if size(gui_data.histology_control_points{gui_data.curr_slice},1) == ...
-        size(gui_data.atlas_control_points{gui_data.curr_slice},1) || ...
-        (size(gui_data.histology_control_points{gui_data.curr_slice},1) > 3 && ...
-        size(gui_data.atlas_control_points{gui_data.curr_slice},1) > 3)
-    align_ccf_to_histology(gui_fig)
-end
-
+	% Draw new point for alignment
+	
+	% Get guidata
+	gui_data = guidata(gui_fig);
+	
+	% Add clicked location to control points
+	gui_data.histology_control_points{gui_data.curr_slice} = ...
+		vertcat(gui_data.histology_control_points{gui_data.curr_slice}, ...
+		eventdata.IntersectionPoint(1:2));
+	
+	set(gui_data.histology_control_points_plot, ...
+		'XData',gui_data.histology_control_points{gui_data.curr_slice}(:,1), ...
+		'YData',gui_data.histology_control_points{gui_data.curr_slice}(:,2));
+	
+	% Upload gui data
+	guidata(gui_fig, gui_data);
+	
+	% If equal number of histology/atlas control points > 3, draw boundaries
+	if size(gui_data.histology_control_points{gui_data.curr_slice},1) == ...
+			size(gui_data.atlas_control_points{gui_data.curr_slice},1) || ...
+			(size(gui_data.histology_control_points{gui_data.curr_slice},1) > 3 && ...
+			size(gui_data.atlas_control_points{gui_data.curr_slice},1) > 3)
+		align_ccf_to_histology(gui_fig)
+	end
+	
 end
 
 
 function mouseclick_atlas(gui_fig,eventdata)
-% Draw new point for alignment
-
-% Get guidata
-gui_data = guidata(gui_fig);
-
-% Add clicked location to control points
-gui_data.atlas_control_points{gui_data.curr_slice} = ...
-    vertcat(gui_data.atlas_control_points{gui_data.curr_slice}, ...
-    eventdata.IntersectionPoint(1:2));
-
-set(gui_data.atlas_control_points_plot, ...
-    'XData',gui_data.atlas_control_points{gui_data.curr_slice}(:,1), ...
-    'YData',gui_data.atlas_control_points{gui_data.curr_slice}(:,2));
-
-% Upload gui data
-guidata(gui_fig, gui_data);
-
-% If equal number of histology/atlas control points > 3, draw boundaries
-if size(gui_data.histology_control_points{gui_data.curr_slice},1) == ...
-        size(gui_data.atlas_control_points{gui_data.curr_slice},1) || ...
-        (size(gui_data.histology_control_points{gui_data.curr_slice},1) > 3 && ...
-        size(gui_data.atlas_control_points{gui_data.curr_slice},1) > 3)
-    align_ccf_to_histology(gui_fig)
-end
-
+	% Draw new point for alignment
+	
+	% Get guidata
+	gui_data = guidata(gui_fig);
+	
+	% Add clicked location to control points
+	gui_data.atlas_control_points{gui_data.curr_slice} = ...
+		vertcat(gui_data.atlas_control_points{gui_data.curr_slice}, ...
+		eventdata.IntersectionPoint(1:2));
+	
+	set(gui_data.atlas_control_points_plot, ...
+		'XData',gui_data.atlas_control_points{gui_data.curr_slice}(:,1), ...
+		'YData',gui_data.atlas_control_points{gui_data.curr_slice}(:,2));
+	
+	% Upload gui data
+	guidata(gui_fig, gui_data);
+	
+	% If equal number of histology/atlas control points > 3, draw boundaries
+	if size(gui_data.histology_control_points{gui_data.curr_slice},1) == ...
+			size(gui_data.atlas_control_points{gui_data.curr_slice},1) || ...
+			(size(gui_data.histology_control_points{gui_data.curr_slice},1) > 3 && ...
+			size(gui_data.atlas_control_points{gui_data.curr_slice},1) > 3)
+		align_ccf_to_histology(gui_fig)
+	end
+	
 end
 
 
 function align_ccf_to_histology(gui_fig)
-
-% Get guidata
-gui_data = guidata(gui_fig);
-
-if size(gui_data.histology_control_points{gui_data.curr_slice},1) == ...
-        size(gui_data.atlas_control_points{gui_data.curr_slice},1) && ...
-        (size(gui_data.histology_control_points{gui_data.curr_slice},1) >= 3 && ...
-        size(gui_data.atlas_control_points{gui_data.curr_slice},1) >= 3)    
-    % If same number of >= 3 control points, use control point alignment
-    tform = fitgeotrans(gui_data.atlas_control_points{gui_data.curr_slice}, ...
-        gui_data.histology_control_points{gui_data.curr_slice},'affine');
-    title(gui_data.histology_ax,'New alignment');
-    
-      
-elseif size(gui_data.histology_control_points{gui_data.curr_slice},1) >= 1 ||  ...
-        size(gui_data.atlas_control_points{gui_data.curr_slice},1) >= 1
-    % If less than 3 or nonmatching points, use auto but don't draw
-    title(gui_data.histology_ax,'New alignment');
-    
-    % Upload gui data
-    guidata(gui_fig, gui_data);
-    return
-    
-else
-    % If no points, use automated outline
-    if isfield(gui_data,'histology_ccf_auto_alignment')
-        tform = affine2d;
-        tform.T = gui_data.histology_ccf_auto_alignment{gui_data.curr_slice};
-        title(gui_data.histology_ax,'Previous alignment');
-    end
-end
-
-curr_av_slice = gui_data.histology_ccf(gui_data.curr_slice).av_slices;
-curr_av_slice(isnan(curr_av_slice)) = 1;
-curr_slice_im = gui_data.slice_im{gui_data.curr_slice};
-
-tform_size = imref2d([size(curr_slice_im,1),size(curr_slice_im,2)]);
-curr_av_slice_warp = imwarp(curr_av_slice, tform, 'OutputView',tform_size);
-
-av_warp_boundaries = round(conv2(curr_av_slice_warp,ones(3)./9,'same')) ~= curr_av_slice_warp;
-
-set(gui_data.histology_aligned_atlas_boundaries, ...
-    'CData',av_warp_boundaries, ...
-    'AlphaData',av_warp_boundaries*0.3);
-
-% Update transform matrix
-gui_data.histology_ccf_manual_alignment{gui_data.curr_slice} = tform.T;
-
-% Upload gui data
-guidata(gui_fig, gui_data);
-
+	
+	% Get guidata
+	gui_data = guidata(gui_fig);
+	
+	if size(gui_data.histology_control_points{gui_data.curr_slice},1) == ...
+			size(gui_data.atlas_control_points{gui_data.curr_slice},1) && ...
+			(size(gui_data.histology_control_points{gui_data.curr_slice},1) >= 3 && ...
+			size(gui_data.atlas_control_points{gui_data.curr_slice},1) >= 3)
+		% If same number of >= 3 control points, use control point alignment
+		tform = fitgeotrans(gui_data.atlas_control_points{gui_data.curr_slice}, ...
+			gui_data.histology_control_points{gui_data.curr_slice},'affine');
+		title(gui_data.histology_ax,'New alignment');
+		
+		%translate
+		tform.T(3,1) = tform.T(3,1) + gui_data.translateX;
+		tform.T(3,2) = tform.T(3,2) + gui_data.translateY;
+		
+		% Update transform matrix
+		gui_data.histology_ccf_manual_alignment{gui_data.curr_slice} = tform.T;
+		
+	elseif size(gui_data.histology_control_points{gui_data.curr_slice},1) >= 1 ||  ...
+			size(gui_data.atlas_control_points{gui_data.curr_slice},1) >= 1
+		% If less than 3 or nonmatching points, use auto but don't draw
+		title(gui_data.histology_ax,'New alignment');
+		
+		% Upload gui data
+		guidata(gui_fig, gui_data);
+		return
+		
+	else
+		% If no points, use automated outline
+		if isfield(gui_data,'histology_ccf_auto_alignment')
+			tform = affine2d;
+			tform.T = gui_data.histology_ccf_auto_alignment{gui_data.curr_slice};
+			title(gui_data.histology_ax,'Previous alignment');
+			
+			%translate
+			tform.T(3,1) = tform.T(3,1) + gui_data.translateX;
+			tform.T(3,2) = tform.T(3,2) + gui_data.translateY;
+		
+			% Update transform matrix
+			gui_data.histology_ccf_manual_alignment{gui_data.curr_slice} = tform.T;
+			
+		end
+	end
+	
+	%do rest
+	curr_av_slice = gui_data.histology_ccf(gui_data.curr_slice).av_slices;
+	curr_av_slice(isnan(curr_av_slice)) = 1;
+	curr_slice_im = gui_data.slice_im{gui_data.curr_slice};
+	
+	tform_size = imref2d([size(curr_slice_im,1),size(curr_slice_im,2)]);
+	curr_av_slice_warp = imwarp(curr_av_slice, tform, 'OutputView',tform_size);
+	
+	av_warp_boundaries = round(conv2(curr_av_slice_warp,ones(3)./9,'same')) ~= curr_av_slice_warp;
+	
+	set(gui_data.histology_aligned_atlas_boundaries, ...
+		'CData',av_warp_boundaries, ...
+		'AlphaData',av_warp_boundaries*0.3);
+	
+	% Upload gui data
+	guidata(gui_fig, gui_data);
+	
 end
 
 
 function update_slice(gui_fig)
-% Draw histology and CCF slice
-
-% Get guidata
-gui_data = guidata(gui_fig);
-
-% Set next histology slice
-set(gui_data.histology_im_h,'CData',gui_data.slice_im{gui_data.curr_slice})
-set(gui_data.atlas_im_h,'CData',gui_data.histology_ccf(gui_data.curr_slice).tv_slices);
-
-% Plot control points for slice
-set(gui_data.histology_control_points_plot, ...
-    'XData',gui_data.histology_control_points{gui_data.curr_slice}(:,1), ...
-    'YData',gui_data.histology_control_points{gui_data.curr_slice}(:,2));
-set(gui_data.atlas_control_points_plot, ...
-    'XData',gui_data.atlas_control_points{gui_data.curr_slice}(:,1), ...
-    'YData',gui_data.atlas_control_points{gui_data.curr_slice}(:,2));
-
-% Reset histology-aligned atlas boundaries if not
-histology_aligned_atlas_boundaries_init = ...
-    zeros(size(gui_data.slice_im{1},1),size(gui_data.slice_im{1},2));
-set(gui_data.histology_aligned_atlas_boundaries, ...
-    'CData',histology_aligned_atlas_boundaries_init, ...
-    'AlphaData',histology_aligned_atlas_boundaries_init);
-
-% Upload gui data
-guidata(gui_fig, gui_data);
-
-% Update atlas boundaries
-align_ccf_to_histology(gui_fig)
-
+	% Draw histology and CCF slice
+	
+	% Get guidata
+	gui_data = guidata(gui_fig);
+	
+	% Set next histology slice
+	set(gui_data.histology_im_h,'CData',gui_data.slice_im{gui_data.curr_slice})
+	set(gui_data.atlas_im_h,'CData',gui_data.histology_ccf(gui_data.curr_slice).tv_slices);
+	
+	% Plot control points for slice
+	set(gui_data.histology_control_points_plot, ...
+		'XData',gui_data.histology_control_points{gui_data.curr_slice}(:,1), ...
+		'YData',gui_data.histology_control_points{gui_data.curr_slice}(:,2));
+	set(gui_data.atlas_control_points_plot, ...
+		'XData',gui_data.atlas_control_points{gui_data.curr_slice}(:,1), ...
+		'YData',gui_data.atlas_control_points{gui_data.curr_slice}(:,2));
+	
+	% Reset histology-aligned atlas boundaries if not
+	histology_aligned_atlas_boundaries_init = ...
+		zeros(size(gui_data.slice_im{1},1),size(gui_data.slice_im{1},2));
+	set(gui_data.histology_aligned_atlas_boundaries, ...
+		'CData',histology_aligned_atlas_boundaries_init, ...
+		'AlphaData',histology_aligned_atlas_boundaries_init);
+	
+	% Upload gui data
+	guidata(gui_fig, gui_data);
+	
+	% Update atlas boundaries
+	align_ccf_to_histology(gui_fig)
+	
 end
 
 

--- a/demo_histology_pipeline.m
+++ b/demo_histology_pipeline.m
@@ -3,13 +3,13 @@
 %% 1) Load CCF and set paths for slide and slice images
 
 % Load CCF atlas
-allen_atlas_path = 'path to CCF atlas goes here';
+allen_atlas_path = 'D:\Data\AllenCCF';
 tv = readNPY([allen_atlas_path filesep 'template_volume_10um.npy']);
 av = readNPY([allen_atlas_path filesep 'annotation_volume_10um_by_index.npy']);
 st = loadStructureTree([allen_atlas_path filesep 'structure_tree_safe_2017.csv']);
 
 % Set paths for histology images and directory to save slice/alignment
-im_path = 'path to folder with images goes here';
+im_path = 'D:\Data\Raw\Histology\MA3\processed';
 slice_path = [im_path filesep 'slices'];
 
 %% 2) Preprocess slide images to produce slice images
@@ -22,7 +22,7 @@ slice_path = [im_path filesep 'slices'];
 
 % Set resize factor
 % resize_factor = []; % (slides ome.tiff: auto-resize ~CCF size 10um/px)
-resize_factor = 1; % (slides tiff: resize factor)
+resize_factor = 0.33; % (slides tiff: resize factor)
 
 % Set slide or slice images
 % slice_images = false; % (images are slides - extract individual slices)


### PR DESCRIPTION
I've added functionality to the manual alignment GUI so you can translate the atlas grid with the arrow keys. My matlab is set to tabs instead of spaces, so it looks like I've changed literally every line, but the changes are actually rather minor. If you search for all the lines with "gui_data.translateX"  or "gui_data.translateY" you should find all the blocks I've changed.