### PR TITLE
Add files to allow conversion to IBL format

### DIFF
--- a/+ap_histology/export_probe_ccf_to_npy.m
+++ b/+ap_histology/export_probe_ccf_to_npy.m
@@ -1,0 +1,33 @@
+function export_probe_ccf_to_npy(~,~,histology_toolbar_gui)
+% Part of AP_histology toolbox
+%
+% Export probe CCF to npy
+
+% Get images (from path in GUI)
+histology_toolbar_guidata = guidata(histology_toolbar_gui);
+
+save_path = histology_toolbar_guidata.save_path;
+probe_filename = fullfile(save_path,'probe_ccf.mat');
+load(probe_filename, 'probe_ccf');
+
+if length(probe_ccf) == 1
+    
+    fname = fullfile(save_path, 'probe_ccf.traj_coords.npy');
+    writeNPY(probe_ccf.trajectory_coords, fname);
+    
+    fname = fullfile(save_path, 'probe_ccf.points.npy');
+    writeNPY(probe_ccf.points, fname);
+    
+else
+    
+    % Write probe_ccf coordinates as NPY file (separately for each shank)
+    for iShank = 1:length(probe_ccf)
+        fname = fullfile(save_path, sprintf('probe_ccf.traj_coords.shank%d.npy', iShank));
+        writeNPY(probe_ccf(iShank).trajectory_coords, fname);
+        
+        fname = fullfile(save_path, sprintf('probe_ccf.points.shank%d.npy', iShank));
+        writeNPY(probe_ccf(iShank).points, fname);
+    end
+end
+fprintf("\nExported to npy files at %s \n", save_path)
+end

--- a/+ap_histology/update_toolbar_gui.m
+++ b/+ap_histology/update_toolbar_gui.m
@@ -25,6 +25,7 @@ gui_data.menu.atlas.Enable = processed_images_present;
 
 gui_data.menu.annotation.Enable = atlas_alignment_present;
 gui_data.menu.view.Enable = atlas_alignment_present;
+gui_data.menu.export.Enable = neuropixels_annotations_present;
 
 
 % Set text

--- a/AP_histology.m
+++ b/AP_histology.m
@@ -81,9 +81,12 @@ gui_data = guidata(histology_toolbar_gui);
 
 % Pick image path
 gui_data.image_path = uigetdir([],'Select path with raw images');
+if gui_data.image_path == 0
+    gui_data.image_path = '';
+end
 
 % Clear processed path (if there's one selected)
-gui_data.save_path = [];
+gui_data.save_path = '';
 
 % Store guidata
 guidata(histology_toolbar_gui,gui_data);
@@ -100,9 +103,8 @@ gui_data = guidata(histology_toolbar_gui);
 
 % Pick image path
 gui_data.save_path = uigetdir([],'Select path to save processing');
-
-if gui_data.image_path == 0
-    gui_data.image_path = gui_data.save_path
+if gui_data.save_path == 0
+    gui_data.save_path = '';
 end
 
 % Store guidata

--- a/AP_histology.m
+++ b/AP_histology.m
@@ -57,6 +57,11 @@ gui_data.menu.view = uimenu(histology_toolbar_gui,'Text','View');
 uimenu(gui_data.menu.view,'Text','View aligned histology','MenuSelectedFcn', ...
     {@ap_histology.view_aligned_histology,histology_toolbar_gui});
 
+% Export menu
+gui_data.menu.export = uimenu(histology_toolbar_gui,'Text','Export');
+uimenu(gui_data.menu.export,'Text','Export track pts to npy','MenuSelectedFcn', ...
+    {@ap_histology.export_probe_ccf_to_npy,histology_toolbar_gui});
+
 % Create GUI variables
 gui_data.image_path = char;
 gui_data.save_path = char;
@@ -95,6 +100,10 @@ gui_data = guidata(histology_toolbar_gui);
 
 % Pick image path
 gui_data.save_path = uigetdir([],'Select path to save processing');
+
+if gui_data.image_path == 0
+    gui_data.image_path = gui_data.save_path
+end
 
 % Store guidata
 guidata(histology_toolbar_gui,gui_data);

--- a/python_scripts/probe_ccf_to_xyz_picks.py
+++ b/python_scripts/probe_ccf_to_xyz_picks.py
@@ -1,0 +1,55 @@
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+from iblatlas.atlas import AllenAtlas
+
+# Requires iblenv conda environment or anything with the ibllib module:
+# See: https://github.com/int-brain-lab/iblenv?tab=readme-ov-file#install-from-scratch
+
+probe_scaling_factor_to_um = (
+    10  # AP histology uses 10um atlas, so we need to scale the probe coordinates by 10
+)
+allen_atlas_res_to_use = 25  # IBL atlas gui uses 25 um atlas, not sure it matters
+atlas = AllenAtlas(allen_atlas_res_to_use)
+
+
+def main(tracing_path):
+    tracing_path = Path(tracing_path)
+    one_shank_pts_files = sorted(list(tracing_path.glob("probe_ccf.points.npy")))
+    multi_shank_pts_files = sorted(
+        list(tracing_path.glob("probe_ccf.points.shank*.npy"))
+    )
+    if len(one_shank_pts_files) > 0 and len(multi_shank_pts_files) > 0:
+        raise ValueError(
+            "Found both single shank ('probe_ccf.points.npy') and\
+             multi shank ('probe_ccf.points.shank*.npy') files.\
+             Please only provide one type of file."
+        )
+
+    pts_files = (
+        one_shank_pts_files if len(one_shank_pts_files) > 0 else multi_shank_pts_files
+    )
+    for iShank, pt_file in enumerate(pts_files):
+        # Load in coordinates of track in CCF space (order - apdvml, origin - top, left, front voxel
+        xyz_apdvml = np.load(pt_file)
+        xyz_apdvml = (xyz_apdvml * probe_scaling_factor_to_um)  # convert from CCF volume coords to microns
+
+        # Convert to IBL space (order - mlapdv, origin - bregma)
+        xyz_mlapdv = (atlas.ccf2xyz(xyz_apdvml, ccf_order="apdvml") * 1e6)  # convert output in meters back to microns (lol)
+        xyz_picks = {"xyz_picks": xyz_mlapdv.tolist()}
+
+        if len(pts_files) == 1:
+            # Path to save the data (same folder as where you have all the data)
+            with open(Path(tracing_path.parent, "xyz_picks.json"), "w") as f:
+                json.dump(xyz_picks, f, indent=2)
+        else:
+            shank_idx = iShank + 1  # IBL shank files are 1-indexed
+            with open(Path(tracing_path.parent, f"xyz_picks_shank{shank_idx}.json"), "w") as f:
+                json.dump(xyz_picks, f, indent=2)
+
+
+if __name__ == "__main__":
+    tracing_path = sys.argv[1]
+    main(tracing_path)


### PR DESCRIPTION
Hi Andy — I'm enjoying using AP histology, thanks for building it! Here I provide two additions and a hopefully minor change:
1) allow export to npy files based on your code [here](https://github.com/petersaj/AP_histology/issues/17#issuecomment-1329028436). I added a tab to the GUI for this.
2) I added a python script that takes the output probe_ccf.npy (or the multi-shank version) and converts that into the xyz_picks (or the multi shank version) required by the IBL atlas ephys gui.
3) very minor-ly, and feel free to reject this, but I made it so that if you open up the GUI fresh and select a save path, the raw data path will auto-populate with that path also. This just reduces the number of clicks from 2 to 1 if you're re-opening a project and have saved the outputs to the same folder as the inputs (which I had).

Let me know if you have any questions. I can confirm that with the latest IBL atlas ephys gui, and some data exported from spikeinterface (using a function that I will be adding there shortly...), I can open the results from this export func + script.

Thanks!